### PR TITLE
Fix: rounding the average rating value of each course

### DIFF
--- a/lib/features/matkul/detail/presentation/pages/detail_matkul_page.dart
+++ b/lib/features/matkul/detail/presentation/pages/detail_matkul_page.dart
@@ -246,7 +246,7 @@ class _DetailMatkulPageState extends BaseStateful<DetailMatkulPage> {
           children: [
             Center(
               child: Text(
-                '${course.ratingAverage ?? 0.0}',
+                '${(course.ratingAverage ?? 0.0).toStringAsFixed(2)}',
                 style: FontTheme.poppins36w700black(),
               ),
             ),

--- a/lib/features/matkul/detail/presentation/pages/detail_matkul_page.dart
+++ b/lib/features/matkul/detail/presentation/pages/detail_matkul_page.dart
@@ -246,7 +246,7 @@ class _DetailMatkulPageState extends BaseStateful<DetailMatkulPage> {
           children: [
             Center(
               child: Text(
-                '${(course.ratingAverage ?? 0.0).toStringAsFixed(2)}',
+                '${(course.ratingAverage ?? 0.0).toStringAsFixed(1)}',
                 style: FontTheme.poppins36w700black(),
               ),
             ),

--- a/lib/features/matkul/detail/presentation/pages/detail_matkul_page.dart
+++ b/lib/features/matkul/detail/presentation/pages/detail_matkul_page.dart
@@ -246,7 +246,7 @@ class _DetailMatkulPageState extends BaseStateful<DetailMatkulPage> {
           children: [
             Center(
               child: Text(
-                '${(course.ratingAverage ?? 0.0).toStringAsFixed(1)}',
+                (course.ratingAverage ?? 0.0).toStringAsFixed(1),
                 style: FontTheme.poppins36w700black(),
               ),
             ),


### PR DESCRIPTION
Fix the following issue by rounding the average rating value displayed under each course's detail page

![S__36618243_0](https://github.com/ristekoss/ulaskelas-frontend/assets/90336772/66676c2f-a450-4324-8a0e-e9e9307f7f38)

![S__36618245_0](https://github.com/ristekoss/ulaskelas-frontend/assets/90336772/a0aeae58-1d8b-4559-a585-85af5e86e995)
